### PR TITLE
Migrating ASPNET Core demo to LTS version

### DIFF
--- a/AspNetCoreMVC.csproj
+++ b/AspNetCoreMVC.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-    <PackageReference Include="Sentry.AspNetCore" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.1" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Sentry.AspNetCore" Version="2.1.8" />
   </ItemGroup>
 
 </Project>

--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 using System.IO;
 using Newtonsoft.Json.Linq;
 using Sentry;
-using Microsoft.AspNetCore.Http.Internal;
+using Microsoft.AspNetCore.Http;
 using AspNetCoreMVC.Controllers;
 using Sentry.AspNetCore;
 

--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -72,7 +72,7 @@ namespace AspNetCoreMVC.Controllers
                 scope.SetTag("CustomerType","Enterprise");
                 });
                 _logger.LogInformation("My custom breadcrumb");
-                //testing corrlelation
+                //implementing fix
                 throw null;
             }
             catch (Exception exception)

--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -72,7 +72,7 @@ namespace AspNetCoreMVC.Controllers
                 scope.SetTag("CustomerType","Enterprise");
                 });
                 _logger.LogInformation("My custom breadcrumb");
-                //implementing fix
+                //implement another fix
                 throw null;
             }
             catch (Exception exception)

--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -68,7 +68,7 @@ namespace AspNetCoreMVC.Controllers
             
             try
             {
-                Sentry.ConfigureScope(scope => {
+                SentrySdk.Scope(scope => {
                 scope.SetTag("CustomerType","Enterprise");
                 });
                 _logger.LogInformation("My breadcrumb", "Setting custom breadcrumb");

--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -71,7 +71,7 @@ namespace AspNetCoreMVC.Controllers
                 SentrySdk.ConfigureScope(scope => {
                 scope.SetTag("CustomerType","Enterprise");
                 });
-                _logger.LogInformation("My breadcrumb", "Setting custom breadcrumb");
+                _logger.LogInformation("My custom breadcrumb");
                 //testing corrlelation
                 throw null;
             }

--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -65,12 +65,17 @@ namespace AspNetCoreMVC.Controllers
         [HttpGet("handled")]
         public string Handled()
         {
+            
             try
             {
+                Sentry.ConfigureScope(scope => {
+                scope.SetTag("CustomerType","Enterprise");
+                });
+                _logger.LogInformation("My breadcrumb", "Setting custom breadcrumb");
                 //testing corrlelation
                 throw null;
             }
-            catch (Exception exception)?
+            catch (Exception exception)
             //add a custom tag, add breadcrumb
             {
                 exception.Data.Add("detail",

--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -67,6 +67,7 @@ namespace AspNetCoreMVC.Controllers
         {
             try
             {
+                //testing corrlelation
                 throw null;
             }
             catch (Exception exception)

--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -70,7 +70,8 @@ namespace AspNetCoreMVC.Controllers
                 //testing corrlelation
                 throw null;
             }
-            catch (Exception exception)
+            catch (Exception exception)?
+            //add a custom tag, add breadcrumb
             {
                 exception.Data.Add("detail",
                     new

--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -68,7 +68,7 @@ namespace AspNetCoreMVC.Controllers
             
             try
             {
-                SentrySdk.Scope(scope => {
+                SentrySdk.ConfigureScope(scope => {
                 scope.SetTag("CustomerType","Enterprise");
                 });
                 _logger.LogInformation("My breadcrumb", "Setting custom breadcrumb");

--- a/Program.cs
+++ b/Program.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore;
-using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Sentry;

--- a/Program.cs
+++ b/Program.cs
@@ -15,7 +15,7 @@ namespace AspNetCoreMVC
     {
         public static void Main(string[] args)
         {
-            CreateWebHostBuilder(args).Build().Run();
+            CreateHostBuilder(args).Build().Run();
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>

--- a/Program.cs
+++ b/Program.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;

--- a/Program.cs
+++ b/Program.cs
@@ -18,9 +18,13 @@ namespace AspNetCoreMVC
             CreateWebHostBuilder(args).Build().Run();
         }
 
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+             Host.CreateDefaultBuilder(args)
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.UseStartup<Startup>()
                 .UseSentry();
+            });
+                
     }
 }

--- a/README.md
+++ b/README.md
@@ -43,3 +43,13 @@ To show how Sentry works in the ASP.NET Core SDK.
 
 # GIF
 ![Alt Text](demo.gif)
+
+## Gotchas 
+
+#### Question: Where is ```Sentry.init()```?
+\
+This demo leverages ASP.NET Core's configuration system. Because of this much of your Sentry config info (dsn etc.) is going to be located in ```appsettings.json```. This allows us to call the ```UseSentry()``` extension method on our webbuilder in ```Program.cs``` without any arguments.
+
+#### Question: How am I setting breadcrumbs without ```SentrySdk.AddBreadcrumb()```?
+\
+This demo utilizes Sentry's integration with ```Microsoft.Extensions.Logging``` to both set  breadcrumbs and send errors. Your ```appsettings.json``` file configures the minimum log levels that correspond to either a crumb or an event. More information here: https://docs.sentry.io/platforms/dotnet/guides/aspnetcore/#configure

--- a/README.md
+++ b/README.md
@@ -5,11 +5,41 @@ To show how Sentry works in the ASP.NET Core SDK.
 - `./AspNetCoreMvc/Controllers/HomeController.cs` contains the REST endpoints for triggering errors captured by Sentry SDK and sent as Events to Sentry
 - The Sentry release cycle is covered in `./AspNetCoreMvc/deploy.ps1`
 
-# Initial Setup & Run
-1. Configure your DSN in [appsettings.json](appsettings.json)
-2. Configure your org slug and project slug in [deploy.ps1](deploy.ps1)
-3. ```SENTRY_RELEASE=`sentry-cli releases propose-version` pwsh deploy.ps1```
-4. `http://localhost:5001/handled` to trigger error and send event to Sentry
+## Versions Summary:
+
+| dependency      | version           
+| ------------- |:-------------:| 
+| .NET Core Runtime      | 3.1.1  |
+| .NET SDK  | 3.1.404   |
+| Sentry SDK  | 2.1.8   |
+| sentry-cli   | 1.62.0   |
+| PowerShell  | 7.1.0   |
+| macOS | Catalina 10.15.6|
+
+
+## First Setup & Run
+1. Install dependencies
+   - Powershell: 
+   https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-macos?view=powershell-7.1
+
+   - .NET Core Runtime & SDK:
+    https://dotnet.microsoft.com/download/dotnet-core/3.1
+
+    - sentry-sdk:
+    ```
+    dotnet add package Sentry.AspNetCore --version 2.1.8
+    ```
+
+2. Configure your DSN in [appsettings.json](appsettings.json)
+
+3. Configure your org slug and project slug in [deploy.ps1](deploy.ps1)
+
+4. Add auth env variable to terminal: 
+```export SENTRY_AUTH_TOKEN=ADD_MY_AUTH_TOKEN_HERE```
+
+5. ```SENTRY_RELEASE=`sentry-cli releases propose-version` pwsh deploy.ps1```
+
+6. `http://localhost:5001/handled` to trigger error and send event to Sentry
 
 # GIF
 ![Alt Text](demo.gif)

--- a/Startup.cs
+++ b/Startup.cs
@@ -36,7 +36,7 @@ namespace AspNetCoreMVC
             });
 
             // services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
-            services.AddControllers();
+            services.addControllers();
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)

--- a/Startup.cs
+++ b/Startup.cs
@@ -39,7 +39,7 @@ namespace AspNetCoreMVC
             services.AddControllers();
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {

--- a/Startup.cs
+++ b/Startup.cs
@@ -36,7 +36,7 @@ namespace AspNetCoreMVC
             });
 
             // services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
-            services.addControllers();
+            services.AddControllers();
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)

--- a/Startup.cs
+++ b/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Hosting;
 
 namespace AspNetCoreMVC
 {

--- a/Startup.cs
+++ b/Startup.cs
@@ -35,7 +35,8 @@ namespace AspNetCoreMVC
                 });
             });
 
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+            // services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+            services.AddControllers();
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
@@ -48,11 +49,13 @@ namespace AspNetCoreMVC
             {
                 app.UseHsts();
             }
-
+            
             app.UseCors();
-
+            app.UseRouting();
             app.UseHttpsRedirection();
-            app.UseMvc();
+            app.UseEndpoints(endpoints => {
+                endpoints.MapControllers();
+            });
         }
     }
 }

--- a/Startup.cs
+++ b/Startup.cs
@@ -35,7 +35,7 @@ namespace AspNetCoreMVC
                 });
             });
 
-            // services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+           
             services.AddControllers();
         }
 

--- a/appsettings.json
+++ b/appsettings.json
@@ -6,7 +6,7 @@
   },
   "AllowedHosts": "*",
   "Sentry": {
-    "Dsn": "https://04970d2e25e94ff2995175884f63b5e8@sentry.io/1453082",
+    "Dsn": "https://4fc5beb02f3d425f96d3f7a647d792dd@o87286.ingest.sentry.io/5583187",
     "IncludeRequestPayload": true,
     "SendDefaultPii": true,
     "MinimumBreadcrumbLevel": "Debug",

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -1,5 +1,5 @@
 $sentry_org="testorg-az"
-$sentry_project="ndmanvar-aspnetcoremvc"
+$sentry_project="aspnet-core-rw"
 $version=sentry-cli releases propose-version
 
 #Create Release


### PR DESCRIPTION
- [x ] Refactoring

Summary:

In preparation to onboard a new client using this demo/framework it was realized that the runtime dependency for this demo was no longer supported.

The edits in this pull request reflect three primary changes:

1. Refactoring/migration of code to account for any breaking changes between .NET CORE 2.2 and 3.1.1
2. Supplementing the setup details in readme.
3. Adding a custom tag and breadcrumb for demo purposes.